### PR TITLE
update to 0.0.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "percy" %}
-{% set version = "0.0.3" %}
+{% set version = "0.0.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/anaconda-distribution/percy/archive/refs/tags/{{ version }}.tar.gz
-  sha256: d43e3b66628994f92bdb6eafc5b107f1b0d70ea42ce92cb8693202f260ba36f8
+  sha256: b3fec5efdeec94effac721e7c00d7f96c4f4a2131319121e6d750fed0a8f9fd8
 
 build:
-  number: 0 # trigger
+  number: 0
   noarch: python
   script: pip install . --no-deps --no-build-isolation -vv
   entry_points:
@@ -29,6 +29,7 @@ requirements:
     - jinja2
     - pyyaml
     - requests
+    - jsonschema
 
 test:
   imports:


### PR DESCRIPTION
Changes:
- Update to 0.0.4

https://github.com/anaconda-distribution/percy/blob/0.0.4/pyproject.toml

(leaving noarch, this is pure python)