### PR TITLE
0.0.5 release

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "percy" %}
-{% set version = "0.0.4" %}
+{% set version = "0.0.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/anaconda-distribution/percy/archive/refs/tags/{{ version }}.tar.gz
-  sha256: b3fec5efdeec94effac721e7c00d7f96c4f4a2131319121e6d750fed0a8f9fd8
+  sha256: f7052aebef35821b2487c13fbc9c332ba1cfcc2c5c5e1320ba3334c64ed65339
 
 build:
   number: 0


### PR DESCRIPTION
Changes:

Update to 0.0.5
https://github.com/anaconda-distribution/percy/blob/0.0.5/pyproject.toml

(leaving noarch, this is pure python)