### PR TITLE
v0.1.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: f2d6d906095d52a79d9c47b3b6699fc7f66e36629f449518175128765871287c
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: pip install . --no-deps --no-build-isolation -vv
   entry_points:
@@ -40,6 +40,7 @@ test:
     - pip
   commands:
     - pip check
+    - python -m pytest -n auto --capture=no percy/tests/
 
 about:
   home: https://github.com/anaconda-distribution/percy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "percy" %}
-{% set version = "0.1.3" %}
+{% set version = "0.1.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/anaconda-distribution/percy/archive/refs/tags/{{ version }}.tar.gz
-  sha256: f2d6d906095d52a79d9c47b3b6699fc7f66e36629f449518175128765871287c
+  sha256: d5895d862482cb9d87f44f76e9e2d8d7a596f3b7a79cb80efe42e7c921268c0c
 
 build:
-  number: 1
+  number: 0
   noarch: python
   script: pip install . --no-deps --no-build-isolation -vv
   entry_points:
@@ -33,14 +33,16 @@ requirements:
 
 test:
   imports:
-    - percy.render.recipe
-    - percy.render.aggregate
-    - percy.repodata.repodata
+    - percy
+  source_files:
+    - percy/tests/
   requires:
     - pip
+    - pytest
+    - pytest-xdist
   commands:
     - pip check
-    - python -m pytest -n auto --capture=no percy/tests/
+    - python -m pytest -n auto percy/tests/
 
 about:
   home: https://github.com/anaconda-distribution/percy


### PR DESCRIPTION
Bump to v0.1.4. Also adds unit tests to the `percy` build, which were missing in previous versions of the recipe file.